### PR TITLE
Add target environment check for Mac Catalyst compatibility

### DIFF
--- a/Sources/ScheduledNotificationsViewController/ScheduledNotificationsViewController.swift
+++ b/Sources/ScheduledNotificationsViewController/ScheduledNotificationsViewController.swift
@@ -244,8 +244,10 @@ extension UNNotificationTrigger {
             } else {
                 return nil
             }
+        #if !targetEnvironment(macCatalyst)
         case is UNLocationNotificationTrigger:
             return "location based"
+        #endif
         default:
             return nil
         }


### PR DESCRIPTION
UNLocationNotificationTrigger is unavailable in Mac Catalyst.